### PR TITLE
Exclude deleted evironments

### DIFF
--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/Deployer.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/Deployer.java
@@ -121,7 +121,8 @@ public class Deployer {
 		DescribeEnvironmentsResult environments = awseb
 				.describeEnvironments(new DescribeEnvironmentsRequest()
 						.withApplicationName(applicationName)
-						.withEnvironmentNames(environmentName));
+						.withEnvironmentNames(environmentName)
+						.withIncludeDeleted(false));
 
 		boolean found = (1 == environments.getEnvironments().size());
 


### PR DESCRIPTION
When an environment is being deleted, it should allow to deploy a new environment with the same name. Therefore, deleted environments should be excluded from search.
