### PR TITLE
Added support for Token Macro Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,11 @@
             <version>1.10.26</version>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>token-macro</artifactId>
+            <version>1.12.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>jenkins-test-harness</artifactId>
             <version>1.625.2</version>

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentConfig.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentConfig.java
@@ -19,7 +19,10 @@ package br.com.ingenieux.jenkins.plugins.awsebdeployment;
 import com.cloudbees.jenkins.plugins.awscredentials.AmazonWebServicesCredentials;
 import lombok.*;
 
+import java.io.IOException;
 import java.io.Serializable;
+
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -94,7 +97,7 @@ public class AWSEBDeploymentConfig implements Serializable {
    * @param r replacer
    * @return replaced copy
    */
-  public AWSEBDeploymentConfig replacedCopy(Utils.Replacer r) {
+  public AWSEBDeploymentConfig replacedCopy(Utils.Replacer r) throws MacroEvaluationException, IOException, InterruptedException {
     return new AWSEBDeploymentConfig(
         r.r(this.getCredentialId()),
         r.r(this.getAwsRegion()),

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/DeployerRunner.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/DeployerRunner.java
@@ -17,7 +17,6 @@
 package br.com.ingenieux.jenkins.plugins.awsebdeployment;
 
 import br.com.ingenieux.jenkins.plugins.awsebdeployment.cmd.DeployerContext;
-import hudson.EnvVars;
 import hudson.FilePath;
 import hudson.Launcher;
 import hudson.model.AbstractBuild;
@@ -43,11 +42,9 @@ public class DeployerRunner {
     }
 
     public boolean perform() throws Exception {
-        EnvVars environment = build.getEnvironment(listener);
-
         AWSEBDeploymentConfig
                 deploymentConfig =
-                deploymentBuilder.asConfig().replacedCopy(new Utils.Replacer(environment));
+                deploymentBuilder.asConfig().replacedCopy(new Utils.Replacer(build, listener));
 
         FilePath
                 rootFileObject =

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/Utils.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/Utils.java
@@ -20,11 +20,14 @@
 package br.com.ingenieux.jenkins.plugins.awsebdeployment;
 
 import org.apache.commons.lang.StringUtils;
+import org.jenkinsci.plugins.tokenmacro.MacroEvaluationException;
+import org.jenkinsci.plugins.tokenmacro.TokenMacro;
 
+import java.io.IOException;
 import java.util.Properties;
 
-import hudson.EnvVars;
-import hudson.Util;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
 
 public class Utils implements Constants {
 
@@ -57,14 +60,19 @@ public class Utils implements Constants {
 
     public static class Replacer {
 
-        final EnvVars envVars;
+        AbstractBuild<?, ?> build;
+        BuildListener listener;
 
-        public Replacer(EnvVars envVars) {
-            this.envVars = envVars;
+        public Replacer( AbstractBuild<?, ?> build, BuildListener listener )
+        {
+            this.build = build;
+            this.listener = listener;
         }
 
-        public String r(String value) {
-            return strip(Util.replaceMacro(value, envVars));
+        public String r( String value )
+            throws MacroEvaluationException, IOException, InterruptedException
+        {
+            return strip( TokenMacro.expandAll( build, listener, value ) );
         }
     }
 


### PR DESCRIPTION
With this, you can use macros like ${GIT_REVISION,length=7} to get a short git commit hash in fields like version label format so you don't have huge version IDs in beanstalk.