### PR TITLE
Tweaks to health and version checks.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,9 +61,6 @@
             <resource>
                 <directory>src/main/resources</directory>
                 <filtering>true</filtering>
-                <includes>
-                    <include>**/version.properties</include>
-                </includes>
             </resource>
         </resources>
         <plugins>

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder.java
@@ -137,11 +137,24 @@ public class AWSEBDeploymentBuilder extends Builder implements BuildStep {
     @Getter
     private boolean zeroDowntime;
 
+    /**
+     * Check Health
+     */
+    @Getter
+    private boolean checkHealth;
+
+    /**
+     * Check Application Version
+     */
+    @Getter
+    private boolean checkApplicationVersion;
+
     @DataBoundConstructor
     public AWSEBDeploymentBuilder(String credentialId, String awsRegion, String applicationName,
                                   String environmentName, String bucketName, String keyPrefix,
                                   String versionLabelFormat, String rootObject, String includes,
-                                  String excludes, boolean zeroDowntime) {
+                                  String excludes, boolean zeroDowntime, boolean checkHealth,
+                                  boolean checkApplicationVersion) {
         this.credentialId = credentialId;
         this.awsRegion = awsRegion;
         this.applicationName = applicationName;
@@ -153,6 +166,8 @@ public class AWSEBDeploymentBuilder extends Builder implements BuildStep {
         this.includes = includes;
         this.excludes = excludes;
         this.zeroDowntime = zeroDowntime;
+        this.checkHealth = checkHealth;
+        this.checkApplicationVersion = checkApplicationVersion;
     }
 
     @Override
@@ -193,6 +208,8 @@ public class AWSEBDeploymentBuilder extends Builder implements BuildStep {
                 includes,
                 excludes,
                 zeroDowntime,
+                checkHealth,
+                checkApplicationVersion,
                 null);
     }
 

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentConfig.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentConfig.java
@@ -87,6 +87,16 @@ public class AWSEBDeploymentConfig implements Serializable {
   private boolean zeroDowntime;
 
   /**
+   * Check Health
+   */
+  private boolean checkHealth;
+
+  /**
+   * Check Application Version
+   */
+  private boolean checkApplicationVersion;
+
+  /**
    * Credentials
    */
   private AmazonWebServicesCredentials credentials;
@@ -110,6 +120,8 @@ public class AWSEBDeploymentConfig implements Serializable {
         r.r(this.getIncludes()),
         r.r(this.getExcludes()),
         this.isZeroDowntime(),
+        this.isCheckHealth(),
+        this.isCheckApplicationVersion(),
         this.credentials
     );
   }

--- a/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/cmd/DeployerChain.java
+++ b/src/main/java/br/com/ingenieux/jenkins/plugins/awsebdeployment/cmd/DeployerChain.java
@@ -96,12 +96,16 @@ public class DeployerChain {
 
             commandList.add(new DeployerCommand.AbortPendingUpdates());
 
-            commandList.add(new DeployerCommand.WaitForEnvironment(WaitFor.Status));
+            commandList.add(new DeployerCommand.WaitForEnvironment(WaitFor.Status, false));
 
             commandList.add(new DeployerCommand.UpdateApplicationVersion());
         }
 
-        commandList.add(new DeployerCommand.WaitForEnvironment(WaitFor.Both));
+        if (c.deployerConfig.isCheckHealth()) {
+            commandList.add(new DeployerCommand.WaitForEnvironment(WaitFor.Both, c.deployerConfig.isCheckApplicationVersion()));
+        } else {
+            commandList.add(new DeployerCommand.WaitForEnvironment(WaitFor.Status, c.deployerConfig.isCheckApplicationVersion()));
+        }
 
         commandList.add(new DeployerCommand.MarkAsSuccessful());
     }

--- a/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/config.jelly
+++ b/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/config.jelly
@@ -82,6 +82,13 @@
             <f:checkbox/>
         </f:entry>
 
+        <f:entry title="Confirm deployed application version?" field="checkApplicationVersion">
+            <f:checkbox/>
+        </f:entry>
+
+        <f:entry title="Ensure Health is Green after deploy?" field="checkHealth">
+            <f:checkbox default="true"/>
+        </f:entry>
 
         <f:validateButton method="validateUpload" title="Explain Upload"
                           with="applicationName,bucketName,keyPrefix,versionLabelFormat"/>

--- a/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/help-checkApplicationVersion.html
+++ b/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/help-checkApplicationVersion.html
@@ -1,0 +1,19 @@
+<!--
+  ~ Copyright 2011 ingenieux Labs
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<div>
+  This check ensures that the deployed version matches the version string you expected to be deployed.  This ensures the build is marked as a failure in the case of a rollback.
+</div>

--- a/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/help-checkHealth.html
+++ b/src/main/resources/br/com/ingenieux/jenkins/plugins/awsebdeployment/AWSEBDeploymentBuilder/help-checkHealth.html
@@ -1,0 +1,19 @@
+<!--
+  ~ Copyright 2011 ingenieux Labs
+  ~
+  ~    Licensed under the Apache License, Version 2.0 (the "License");
+  ~    you may not use this file except in compliance with the License.
+  ~    You may obtain a copy of the License at
+  ~
+  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing, software
+  ~    distributed under the License is distributed on an "AS IS" BASIS,
+  ~    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~    See the License for the specific language governing permissions and
+  ~    limitations under the License.
+  -->
+
+<div>
+  Uncheck this to disable the Health check on deploy.  Some implementations may not care to wait until the environment shows "Green".
+</div>


### PR DESCRIPTION
This adds support for disabling the Health check after you deploy (I specifically don't want to use this), and also adds support for checking to ensure the correct application version was deployed.

This fixes a bug where the beanstalk app can rollback due to a deployment failure, yet the status on the job was still reporting green, the application version check makes this report as red.

Both of these are options.

I haven't written Java for about a decade, and I've never written a jenkins plugin. So you will want to review this with eagle eyes.